### PR TITLE
Tweak firewall (Kindle) rules to allow further sync protocol traffic 

### DIFF
--- a/syncthing.koplugin/main.lua
+++ b/syncthing.koplugin/main.lua
@@ -71,6 +71,9 @@ function Syncthing:start(password)
         os.execute(string.format("%s %s %s",
             "iptables -A OUTPUT -p tcp --sport", self.syncthing_port,
             "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
+	os.execute("iptables -A INPUT -i wlan0 -p tcp --dport 22000 -j ACCEPT")
+	os.execute("iptables -A INPUT -i wlan0 -p udp --dport 22000 -j ACCEPT")
+	os.execute("iptables -A INPUT -i wlan0 -p udp --dport 21027 -j ACCEPT")
     end
 
     if not util.pathExists(path.."/settings/syncthing/") then
@@ -118,6 +121,9 @@ function Syncthing:stop()
         os.execute(string.format("%s %s %s",
             "iptables -D OUTPUT -p tcp --sport", self.syncthing_port,
             "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
+	os.execute("iptables -D INPUT -i wlan0 -p tcp --dport 22000 -j ACCEPT")
+	os.execute("iptables -D INPUT -i wlan0 -p udp --dport 22000 -j ACCEPT")
+	os.execute("iptables -D INPUT -i wlan0 -p udp --dport 21027 -j ACCEPT")
     end
 end
 


### PR DESCRIPTION
I have found that larger files (books) fail to synchronize without at least 22000 being opened - "gets stuck on preparing to Sync", so I implement the documented ports (I have found that larger files (books) fail to synchronize without at least 22000 being opened, so I implement the documented ports alongside the existing rules for the GUI port.) alongside the existing rules for the GUI port.

This seems to do the trick on my 12 year old Kindle PW and thought it might be useful.