### PR TITLE
Update README.md to Reflect New Location of Menu Item

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The method of running Syncthing is originally based on [The Anarcat's blog post]
 
 ### Configure devices and folders
 
-4.  The Syncthing menu will be available under the Tools tab in the file
-    browser. Check *Syncthing* menu item to start the Syncthing server. Make
-    sure the e-reader is also connected to Wi-Fi.
+4.  The Syncthing menu will be available under the Bookmarks (or Tools) tab in the top
+    menu when a document is open. Check *Syncthing* menu item to start the Syncthing server. 
+    Make sure the e-reader is also connected to Wi-Fi.
 5.  On your other Syncthing device, add the e-reader by scanning the QR code or
     entering the device ID manually.
 6.  Go to the *Pending* menu and accept the device.


### PR DESCRIPTION
Changed the location of the menu item per issue #22. I can't figure out how to screenshot while the menu is open, but the screenshot in the README that shows the item in the Tools tab may also be inaccurate going forward.