### PR TITLE
fix tools menu

### DIFF
--- a/syncthing.koplugin/main.lua
+++ b/syncthing.koplugin/main.lua
@@ -509,6 +509,7 @@ function Syncthing:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("Syncthing"),
+                sorting_hint = "tools",
                 keep_menu_open = true,
                 checked_func = function() return self:isRunning() end,
                 callback = function(touchmenu_instance)


### PR DESCRIPTION
Fix https://github.com/jasonchoimtt/koreader-syncthing/issues/22
Make syncthing in tools menu instead of bookmarks