### PR TITLE
fix: get device id

### DIFF
--- a/syncthing.koplugin/start-syncthing
+++ b/syncthing.koplugin/start-syncthing
@@ -34,13 +34,10 @@ if [ ! -f "$config_dir/config.xml" ] || [ -n "$password" ]; then
         --no-port-probing # Need this due to lack of IPv4 loopback in Kobo
 fi
 
-if [ ! -f "$config_dir/device-id" ]; then
-    # Save the device ID to a file for easy access from KOReader
-    "$syncthing" \
-        --config="$config_dir" \
-        --data="$config_dir" \
-        --device-id > "$config_dir/device-id"
-fi
+# Save the device ID to a file for easy access from KOReader
+"$syncthing" device-id \
+    --config="$config_dir" \
+    --data="$config_dir" > "$config_dir/device-id"
 
 # We need to listen to 0.0.0.0 so that the GUI is accessible over the network
 "$syncthing" serve \


### PR DESCRIPTION
There are two issues that stop the plugin from getting the device ID of Syncthing:

1. According to the [Syncthing document](https://docs.syncthing.net/v2.0.0/users/syncthing.html), we should get the device ID by `syncthing device-id [args]` instead of `syncthing --device-id [args]`, which is an outdated method.

2. If the plugin fetched an old or empty (because it failed) ID before, the start script won't update it again because it already exists.

This PR should fix these two issues.