### PR TITLE
Fix: Handle nil callback to prevent crash during Dispatcher toggle

### DIFF
--- a/syncthing.koplugin/main.lua
+++ b/syncthing.koplugin/main.lua
@@ -139,13 +139,15 @@ function Syncthing:stop()
 end
 
 function Syncthing:onToggleSyncthingServer(callback)
+    local safe_callback = type(callback) == "function" and callback or function() end
+
     if self:isRunning() then
         self:stop()
-        callback()
+        safe_callback()
     else
         NetworkMgr:runWhenOnline(function()
             self:start()
-            callback()
+            safe_callback()
         end)
     end
 end


### PR DESCRIPTION
### The Issue
Currently, triggering `ToggleSyncthingServer` via KOReader's Dispatcher crashes the UI. I discovered this when triggering the toggle via a Quick Action on the home screen using the [SimpleUI plugin](https://github.com/doctorhetfield-cmd/simpleui.koplugin).

Because the Dispatcher (used by SimpleUI shortcuts, swipe gestures, and hardware buttons) does not pass a `callback` function, `main.lua` attempts to call a `nil` value when updating the UI state at the end of the toggle execution. 

This results in the following crash and kicks the user out of KOReader:
`ERROR An error occurred while executing handler Syncthing:onToggleSyncthingServer: plugins/syncthing.koplugin/main.lua:144: attempt to call local 'callback' (a nil value)`

### The Fix
Added a type-safe fallback function (`safe_callback`) at the beginning of `onToggleSyncthingServer`. 

If `callback` is missing or is not a function, it gracefully falls back to an empty function. This allows the server to safely start/stop in the background and display the standard `InfoMessage` dialogs, while cleanly bypassing the menu redraw if no menu is currently open. 

Tested on - Kindle PW6 (12th Generation, 2024) and working