### PR TITLE
Fix isRunning() so autostart works after syncthing exits ungracefully

### DIFF
--- a/syncthing.koplugin/main.lua
+++ b/syncthing.koplugin/main.lua
@@ -110,7 +110,15 @@ function Syncthing:start(password)
 end
 
 function Syncthing:isRunning()
-    return util.pathExists(pid_path)
+    if not util.pathExists(pid_path) then return false end
+    local f = io.open(pid_path, "r")
+    if not f then return false end
+    local pid = tonumber(f:read("*l") or "")
+    f:close()
+    if pid and util.pathExists("/proc/" .. pid) then return true end
+    -- Stale PID file: clean it up so a fresh start is allowed
+    os.remove(pid_path)
+    return false
 end
 
 function Syncthing:stop()


### PR DESCRIPTION
### Problem

`Syncthing:isRunning()` returns `true` whenever the PID file exists, regardless of whether the PID inside is a live process. The PID file is written by `start-syncthing` and never cleaned up when syncthing exits. Result: any time syncthing dies without removing its own PID file (crash, OOM, suspend-induced kill on Kindle, parent process going away), the file is left behind and **autostart silently bails on every subsequent KOReader launch**:

```lua
function Syncthing:start(password)
    if self:isRunning() then
        logger.dbg("[Syncthing] Not starting Syncthing, already running.")
        return    -- ← we land here forever
    end
    ...
end
```

The `logger.dbg` is debug-level so the failure is invisible in normal logs. The user sees: plugin enabled, autostart toggled on, no syncthing process, no error message.

### Repro

On any device, with `syncthing_autostart = true`:

1. Launch KOReader → autostart fires → syncthing starts → `/tmp/syncthing_koreader.pid` written
2. Force-kill syncthing without going through `Syncthing:stop()`. On Kindle this happens naturally during deep suspend; you can simulate with `kill -9 \$(cat /tmp/syncthing_koreader.pid)` then `kill -9` the child.
3. Confirm: `ls /tmp/syncthing_koreader.pid` exists, `ps | grep syncthing` empty.
4. Restart KOReader. Expected: syncthing comes back. Actual: it doesn't, ever, until the user manually deletes the PID file or reboots (clears `/tmp` on tmpfs).

In our case (Kindle Oasis 10th gen / `KindleOasis3`, KOReader v2026.03) the device goes into deep suspend daily, syncthing dies without cleanup, and reading progress stops syncing for days at a time even though the user thinks the plugin is on.

### Fix

`isRunning()` checks the PID file *and* verifies the PID is still alive via `/proc/<pid>`. If the PID file is stale, it's removed so the next `start()` call succeeds.

```diff
 function Syncthing:isRunning()
-    return util.pathExists(pid_path)
+    if not util.pathExists(pid_path) then return false end
+    local f = io.open(pid_path, "r")
+    if not f then return false end
+    local pid = tonumber(f:read("*l") or "")
+    f:close()
+    if pid and util.pathExists("/proc/" .. pid) then return true end
+    -- Stale PID file: clean it up so a fresh start is allowed
+    os.remove(pid_path)
+    return false
 end
```

### Edge cases considered

- **Empty/garbage PID file**: `tonumber(... or "")` → nil → falls through to remove + return false.
- **PID reuse**: `/proc/<pid>` would point at *something*, possibly not syncthing. In practice on Kindle/Kobo this is extremely unlikely on the timescales involved (minutes to hours between restarts, low PID churn). If you'd prefer the paranoid version, we can also read `/proc/<pid>/comm` and require it to contain "syncthing"; happy to amend.
- **Portability**: `/proc/<pid>` exists on all KOReader-supported targets where this plugin runs (Linux Kindle/Kobo, Android, desktop Linux). On Apple/Windows desktop builds the plugin already gates on `dropbear` existing at startup, so this code path is unreachable there.

### Verification

Patched on a Kindle Oasis 10th gen (KOReader's `KindleOasis3`) running KOReader v2026.03 with bundled syncthing v2.0.16. Before patch: syncthing autostart hadn't actually fired in days despite the plugin being enabled. After patch + restart of KOReader: syncthing process appears within 1s of plugin init, NAS-side Syncthing immediately reports `connected=True`, sidecar push goes through. Repeated kill-and-relaunch cycles confirm the stale PID file is now correctly cleaned up each time.